### PR TITLE
control sequence number generation and storage

### DIFF
--- a/lib/smppex/ets_sequence_storage.ex
+++ b/lib/smppex/ets_sequence_storage.ex
@@ -1,0 +1,52 @@
+defmodule SMPPEX.EtsSequenceStorage do
+
+  use GenServer
+
+  alias :ets, as: ETS
+
+  @default_next_sequence_number 1
+
+  def start_link() do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def init([]) do
+    {:ok, %{}}
+  end
+
+  @doc """
+    create sequence number table and key
+  """
+  def init_seq(), do: GenServer.call(__MODULE__, :init_seq)
+
+  @doc """
+  returns the next sequence number
+  """
+  def get_next_seq(seq_table, seq_key), do: GenServer.call(__MODULE__, {:get_next_seq, seq_table, seq_key})
+
+  @doc """
+  stores last sequence number
+  """
+  def save_next_seq(seq_table, seq_key, seq_number) do
+    GenServer.call(__MODULE__, {:save_next_seq, seq_table, seq_key, seq_number})
+  end
+
+  def handle_call(:init_seq, _from, st) do
+    seq_table = ETS.new(:sequence_number, [:set, :protected])
+    seq_key = :crypto.strong_rand_bytes(10) |> Base.url_encode64 |> binary_part(0, 10)
+    {:reply, {seq_table, seq_key}, st}
+  end
+
+  def handle_call({:get_next_seq, seq_table, seq_key}, _from, st) do
+    case ETS.lookup(seq_table, seq_key) do
+      [] -> {:reply, @default_next_sequence_number, st}
+      [{^seq_key, sequence_number}] -> {:reply, sequence_number, st}
+    end
+  end
+
+  def handle_call({:save_next_seq, seq_table, seq_key, seq_number}, _from, st) do
+    :ets.insert(seq_table, {seq_key, seq_number})
+    {:reply, seq_number, st}
+  end
+
+end

--- a/lib/smppex/mem_sequence_storage.ex
+++ b/lib/smppex/mem_sequence_storage.ex
@@ -7,8 +7,6 @@ defmodule SMPPEX.MemSequenceStorage do
 
   use GenServer
 
-  alias :ets, as: ETS
-
   @default_next_sequence_number 1
 
   def start_link() do
@@ -28,6 +26,10 @@ defmodule SMPPEX.MemSequenceStorage do
   returns the next sequence number
   """
   def get_next_seq(seq_table, seq_key), do: GenServer.call(__MODULE__, {:get_next_seq, seq_table, seq_key})
+
+  def state do
+    GenServer.call(__MODULE__, :state)
+  end
 
   @doc """
   stores last sequence number
@@ -51,14 +53,12 @@ defmodule SMPPEX.MemSequenceStorage do
   end
 
   def handle_call({:save_next_seq, seq_table, seq_key, seq_number}, _from, st) do
-    new_st = case st do
-      %{ ^seq_table => %{ ^seq_key => _ } } -> %{ seq_table => %{ seq_key => seq_number } }
-      _ -> %{ seq_table => %{ seq_key => @default_next_sequence_number }}
-    end
-    new_st = Map.merge(st, new_st)
+    new_st = Map.merge(st, %{ seq_table => %{ seq_key => seq_number}})
     {:reply, seq_number, new_st}
   end
 
-
+  def handle_call(:state, _from, st) do
+    {:reply, st, st}
+  end
   
 end

--- a/lib/smppex/pdu_storage.ex
+++ b/lib/smppex/pdu_storage.ex
@@ -27,9 +27,9 @@ defmodule SMPPEX.PduStorage do
       [seq_table: seq_table, seq_key: seq_key, seq_store: seq_store] ->
         Enum.into([seq_table: seq_table, seq_key: seq_key, seq_store: seq_store], %{})
       _ ->
-        SMPPEX.EtsSequenceStorage.start_link()
-        {seq_table, seq_key} = SMPPEX.EtsSequenceStorage.init_seq()
-        Enum.into(params, %{seq_table: seq_table, seq_key: seq_key, seq_store: SMPPEX.EtsSequenceStorage})
+        SMPPEX.MemSequenceStorage.start_link()
+        {seq_table, seq_key} = SMPPEX.MemSequenceStorage.init_seq()
+        Enum.into(params, %{seq_table: seq_table, seq_key: seq_key, seq_store: SMPPEX.MemSequenceStorage})
     end
 
     GenServer.start_link(__MODULE__, params, opts)

--- a/lib/smppex/pdu_storage.ex
+++ b/lib/smppex/pdu_storage.ex
@@ -3,24 +3,36 @@ defmodule SMPPEX.PduStorage do
 
   use GenServer
 
+  require Integer
+
   alias :ets, as: ETS
 
   alias SMPPEX.PduStorage
   alias SMPPEX.Pdu
 
-  @default_next_sequence_number 1
-
   defstruct [
     :by_sequence_number,
-    :next_sequence_number
+    :next_sequence_number,
+    :seq_table,
+    :seq_key,
+    :seq_store
   ]
 
   @type t :: %PduStorage{}
+  @spec start_link(list, list) :: GenServer.on_start
 
-  @spec start_link :: GenServer.on_start
+  def start_link(params \\ [], opts \\ []) do
 
-  def start_link(next_sequence_number \\ @default_next_sequence_number, opts \\ []) do
-    GenServer.start_link(__MODULE__, [next_sequence_number], opts)
+    params = case params do
+      [seq_table: seq_table, seq_key: seq_key, seq_store: seq_store] ->
+        Enum.into([seq_table: seq_table, seq_key: seq_key, seq_store: seq_store], %{})
+      _ ->
+        SMPPEX.EtsSequenceStorage.start_link()
+        {seq_table, seq_key} = SMPPEX.EtsSequenceStorage.init_seq()
+        Enum.into(params, %{seq_table: seq_table, seq_key: seq_key, seq_store: SMPPEX.EtsSequenceStorage})
+    end
+
+    GenServer.start_link(__MODULE__, params, opts)
   end
 
   @spec store(pid, Pdu.t, non_neg_integer) :: boolean
@@ -42,27 +54,44 @@ defmodule SMPPEX.PduStorage do
   end
 
   @spec reserve_sequence_number(pid) :: :pos_integer
-
   @doc """
-  Reserve a sequence number by getting current next sequence number and then incrementing.
+  Reserve a sequence number by gettingfl current next sequence number and then incrementing.
   Useful if you need to track sequence numbers externally.
   """
-
   def reserve_sequence_number(pid) do
     GenServer.call(pid, :reserve_sequence_number)
   end
 
-  def init([next_sequence_number]) do
+  @spec stop(pid) :: :any
+  def stop(pid), do: GenServer.cast(pid, :stop)
+
+  def state(pid), do: GenServer.call(pid, :state)
+
+  def init(params) do
+
+    next_sequence_number = case Map.has_key?(params, :next_sequence_number) do
+      true ->
+        params.next_sequence_number
+      false ->
+        params.seq_store.get_next_seq(params.seq_table, params.seq_key)
+    end
+
+    Process.flag(:trap_exit, true)
     {:ok, %PduStorage{
       by_sequence_number: ETS.new(:pdu_storage_by_sequence_number, [:set]),
-      next_sequence_number: next_sequence_number
+      next_sequence_number: next_sequence_number,
+      seq_table: params.seq_table,
+      seq_key: params.seq_key,
+      seq_store: params.seq_store
     }}
   end
 
-  def handle_cast(:reset_sequence_number, st) do
-    st = %PduStorage{st | next_sequence_number: @default_next_sequence_number}
+  def handle_cast(:stop, st) do
+    raise StopException
     {:noreply, st}
   end
+
+  def handle_call(:state, _from, st), do: {:reply, st, st}
 
   def handle_call({:store, pdu, expire_time}, _from, st) do
     sequence_number = Pdu.sequence_number(pdu)
@@ -89,11 +118,30 @@ defmodule SMPPEX.PduStorage do
 
   def handle_call(:reserve_sequence_number, _from, st) do
     {sequence_number, new_st} = increment_sequence_number(st)
+
+    cond do
+      Integer.mod(new_st.next_sequence_number, 100) == 0 ->
+        st.seq_store.save_next_seq(st.seq_table, st.seq_key, new_st.next_sequence_number)
+      true -> true
+    end
+
     {:reply, sequence_number, new_st}
+  end
+
+  def terminate(_reason, st) do
+    st.seq_store.save_next_seq(st.seq_table, st.seq_key, st.next_sequence_number)
   end
 
   defp increment_sequence_number(st) do
     {st.next_sequence_number, %PduStorage{st | next_sequence_number: st.next_sequence_number + 1}}
   end
 
+end
+
+defmodule StopException do
+  defexception message: "stopping process on request"
+end
+
+defimpl String.Chars, for: StopException do
+  def to_string(exception), do: exception.message
 end

--- a/lib/smppex/pdu_storage_supervisor.ex
+++ b/lib/smppex/pdu_storage_supervisor.ex
@@ -14,7 +14,7 @@ defmodule SMPPEX.PduStorageSupervisor do
     instanciate new supervised PDU storage worker
   """
   def pdu_storage() do
-    pdu_storage(SMPPEX.EtsSequenceStorage)
+    pdu_storage(SMPPEX.MemSequenceStorage)
   end
 
   def pdu_storage(seq_store) do
@@ -35,7 +35,7 @@ defmodule SMPPEX.PduStorageSupervisor do
   end
 
   def seq_storage(seq_store) do
-    seq_storage_worker_spec = worker(SMPPEX.EtsSequenceStorage, [])
+    seq_storage_worker_spec = worker(seq_store, [])
     Supervisor.start_child(__MODULE__, seq_storage_worker_spec)
   end
   

--- a/lib/smppex/pdu_storage_supervisor.ex
+++ b/lib/smppex/pdu_storage_supervisor.ex
@@ -1,0 +1,42 @@
+defmodule SMPPEX.PduStorageSupervisor do
+  use Supervisor
+
+  def start_link() do
+    Supervisor.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def init([]) do
+    childern = []
+    supervise childern, strategy: :one_for_one
+  end
+
+  @doc """
+    instanciate new supervised PDU storage worker
+  """
+  def pdu_storage() do
+    pdu_storage(SMPPEX.EtsSequenceStorage)
+  end
+
+  def pdu_storage(seq_store) do
+    seq_storage(seq_store)
+
+    {seq_table, seq_key} = seq_store.init_seq()
+    process_name = "pdu_storage_#{seq_key}" |> String.to_atom
+    pdu_storage_worker_spec = worker(
+      SMPPEX.PduStorage,
+      [
+        [seq_table: seq_table, seq_key: seq_key, seq_store: seq_store],
+        [name: process_name],
+      ],
+      id: process_name
+    )
+    {:ok, pdu_storage_pid} = Supervisor.start_child(__MODULE__, pdu_storage_worker_spec)
+    {pdu_storage_pid, process_name}
+  end
+
+  def seq_storage(seq_store) do
+    seq_storage_worker_spec = worker(SMPPEX.EtsSequenceStorage, [])
+    Supervisor.start_child(__MODULE__, seq_storage_worker_spec)
+  end
+  
+end

--- a/lib/smppex/sequence_storage.ex
+++ b/lib/smppex/sequence_storage.ex
@@ -1,0 +1,9 @@
+defmodule SMPPEX.SequenceStorage do
+  @moduledoc """
+    The purpose of this behaviour, is to allow custom sequence number storage, to allow for persistent tracking
+    of sequence numbers
+  """
+  @callback init_seq() :: {String.t, String.t}
+  @callback get_next_seq(String.t, String.t) :: integer
+  @callback save_next_seq(String.t, String.t, integer) :: integer
+end

--- a/test/esme_ext_seq_num_test.exs
+++ b/test/esme_ext_seq_num_test.exs
@@ -13,7 +13,7 @@ defmodule SMPPEX.ESMEExtSeqNumTest do
     server = Server.start_link
     Timer.sleep(50)
 
-    {:ok, pdu_storage_pid} = PduStorage.start_link 100
+    {:ok, pdu_storage_pid} = PduStorage.start_link [next_sequence_number: 100]
 
     {callback_backup, esme} = SupportESME.start_link({127,0,0,1}, Server.port(server), [
       enquire_link_limit: 1000,

--- a/test/ets_sequence_storage_test.exs
+++ b/test/ets_sequence_storage_test.exs
@@ -1,0 +1,20 @@
+defmodule EtsSequenceStorageTest do
+ use ExUnit.Case
+
+ alias SMPPEX.EtsSequenceStorage, as: Storage
+
+ setup do
+   {:ok, pid} = Storage.start_link
+   {table, key} = Storage.init_seq()
+   {:ok, %{pid: pid, table: table, key: key}}
+ end
+
+ test "store sequence number", ctx do
+
+   assert 1 == Storage.get_next_seq(ctx.table, ctx.key)
+   assert 1001 == Storage.save_next_seq(ctx.table, ctx.key, 1001)
+   assert 1001 == Storage.get_next_seq(ctx.table, ctx.key)
+
+ end
+
+end

--- a/test/mem_sequence_storage_test.exs
+++ b/test/mem_sequence_storage_test.exs
@@ -1,0 +1,20 @@
+defmodule SMPPEX.MemSequenceStorageTest do
+  use ExUnit.Case
+
+  alias SMPPEX.MemSequenceStorage, as: Storage
+
+  setup do
+    {:ok, pid} = Storage.start_link
+    {table, key} = Storage.init_seq()
+    {:ok, %{pid: pid, table: table, key: key}}
+  end
+
+  test "store sequence number", ctx do
+
+    assert 1 == Storage.get_next_seq(ctx.table, ctx.key)
+    assert 1001 == Storage.save_next_seq(ctx.table, ctx.key, 1001)
+    assert 1001 == Storage.get_next_seq(ctx.table, ctx.key)
+
+  end
+  
+end

--- a/test/pdu_storage_test.exs
+++ b/test/pdu_storage_test.exs
@@ -11,7 +11,7 @@ defmodule SMPPEX.PduStorageTest do
   end
 
   setup do
-    {pid, process} = PduStorageSupervisor.pdu_storage(SMPPEX.EtsSequenceStorage)
+    {pid, process} = PduStorageSupervisor.pdu_storage(SMPPEX.MemSequenceStorage)
     {:ok, %{pid: pid, process: process}}
   end
 

--- a/test/pdu_storage_test.exs
+++ b/test/pdu_storage_test.exs
@@ -11,7 +11,7 @@ defmodule SMPPEX.PduStorageTest do
   end
 
   setup do
-    {pid, process} = PduStorageSupervisor.pdu_storage()
+    {pid, process} = PduStorageSupervisor.pdu_storage(SMPPEX.EtsSequenceStorage)
     {:ok, %{pid: pid, process: process}}
   end
 
@@ -84,7 +84,7 @@ defmodule SMPPEX.PduStorageTest do
     assert 3 == PduStorage.reserve_sequence_number(ctx.pid)
     assert 4 == PduStorage.reserve_sequence_number(ctx.pid)
 
-    {pid, process} = PduStorageSupervisor.pdu_storage()
+    {pid, _process} = PduStorageSupervisor.pdu_storage()
     assert 1 == PduStorage.reserve_sequence_number(pid)
     assert 2 == PduStorage.reserve_sequence_number(pid)
     assert 3 == PduStorage.reserve_sequence_number(pid)

--- a/test/pdu_storage_test.exs
+++ b/test/pdu_storage_test.exs
@@ -2,55 +2,99 @@ defmodule SMPPEX.PduStorageTest do
   use ExUnit.Case
 
   alias SMPPEX.PduStorage
+  alias SMPPEX.PduStorageSupervisor
   alias SMPPEX.Pdu
 
-  test "store" do
-    {:ok, pid} = PduStorage.start_link
+  setup_all do
+    PduStorageSupervisor.start_link()
+    :ok
+  end
+
+  setup do
+    {pid, process} = PduStorageSupervisor.pdu_storage()
+    {:ok, %{pid: pid, process: process}}
+  end
+
+  test "store", ctx do
 
     pdu1 = %Pdu{SMPPEX.Pdu.Factory.bind_transmitter("system_id1", "pass1") | sequence_number: 123}
     pdu2 = %Pdu{SMPPEX.Pdu.Factory.bind_transmitter("system_id2", "pass2") | sequence_number: 123}
 
-    assert true == PduStorage.store(pid, pdu1, 321)
-    assert false == PduStorage.store(pid, pdu2, 321)
-
-    pdus = PduStorage.fetch(pid, 123)
+    assert true == PduStorage.store(ctx.pid, pdu1, 321)
+    assert false == PduStorage.store(ctx.pid, pdu2, 321)
+    pdus = PduStorage.fetch(ctx.pid, 123)
 
     assert pdus == [pdu1]
   end
 
-  test "fetch" do
-    {:ok, pid} = PduStorage.start_link
+  test "fetch", ctx do
 
     pdu = %Pdu{SMPPEX.Pdu.Factory.bind_transmitter("system_id", "pass") | sequence_number: 123}
 
-    assert true == PduStorage.store(pid, pdu, 321)
+    assert true == PduStorage.store(ctx.pid, pdu, 321)
 
-    assert [pdu] == PduStorage.fetch(pid, 123)
-    assert [] == PduStorage.fetch(pid, 124)
+    assert [pdu] == PduStorage.fetch(ctx.pid, 123)
+    assert [] == PduStorage.fetch(ctx.pid, 124)
   end
 
-  test "expire" do
-    {:ok, pid} = PduStorage.start_link
-
+  test "expire", ctx do
     pdu1 = %Pdu{SMPPEX.Pdu.Factory.bind_transmitter("system_id1", "pass") | sequence_number: 123}
     pdu2 = %Pdu{SMPPEX.Pdu.Factory.bind_transmitter("system_id2", "pass") | sequence_number: 124}
 
-    assert true == PduStorage.store(pid, pdu1, 1000)
-    assert true == PduStorage.store(pid, pdu2, 2000)
+    assert true == PduStorage.store(ctx.pid, pdu1, 1000)
+    assert true == PduStorage.store(ctx.pid, pdu2, 2000)
 
-    assert [pdu1] == PduStorage.fetch_expired(pid, 1500)
-    assert [] == PduStorage.fetch(pid, 123)
-    assert [pdu2] == PduStorage.fetch(pid, 124)
+    assert [pdu1] == PduStorage.fetch_expired(ctx.pid, 1500)
+    assert [] == PduStorage.fetch(ctx.pid, 123)
+    assert [pdu2] == PduStorage.fetch(ctx.pid, 124)
   end
 
-  test "reserve sequence number" do
-    {:ok, pid} = PduStorage.start_link 100
+  test "reserve sequence number", ctx do
 
     SMPPEX.Pdu.Factory.bind_transmitter("system_id", "password")
-    reserve_sequence_number  = PduStorage.reserve_sequence_number(pid)
-    assert 100 == reserve_sequence_number
-    assert 101 == PduStorage.reserve_sequence_number(pid)
-    assert 102 == PduStorage.reserve_sequence_number(pid)
+    reserve_sequence_number  = PduStorage.reserve_sequence_number(ctx.pid)
+    assert 1 == reserve_sequence_number
+    assert 2 == PduStorage.reserve_sequence_number(ctx.pid)
+    assert 3 == PduStorage.reserve_sequence_number(ctx.pid)
+    assert 4 == PduStorage.reserve_sequence_number(ctx.pid)
+
+    #Process.exit(ctx.pid, :kill)
+    PduStorage.stop(ctx.pid)
+    :timer.sleep(1000)
+    assert ctx.pid != Process.whereis(ctx.process)
+
+    assert 5 == PduStorage.reserve_sequence_number(ctx.process)
+
+  end
+
+  test "save on every 100 sequence numbers", ctx do
+
+    SMPPEX.Pdu.Factory.bind_transmitter("system_id", "password")
+    1..100 |> Enum.to_list |> Enum.each(fn _x -> PduStorage.reserve_sequence_number(ctx.pid) end)
+    %{seq_table: seq_table, seq_key: seq_key, seq_store: seq_store} = PduStorage.state(ctx.pid)
+    assert 100 == seq_store.get_next_seq(seq_table, seq_key)
+
+  end
+
+  test "isolation", ctx do
+
+    SMPPEX.Pdu.Factory.bind_transmitter("system_id", "password")
+    assert 1 == PduStorage.reserve_sequence_number(ctx.pid)
+    assert 2 == PduStorage.reserve_sequence_number(ctx.pid)
+    assert 3 == PduStorage.reserve_sequence_number(ctx.pid)
+    assert 4 == PduStorage.reserve_sequence_number(ctx.pid)
+
+    {pid, process} = PduStorageSupervisor.pdu_storage()
+    assert 1 == PduStorage.reserve_sequence_number(pid)
+    assert 2 == PduStorage.reserve_sequence_number(pid)
+    assert 3 == PduStorage.reserve_sequence_number(pid)
+    assert 4 == PduStorage.reserve_sequence_number(pid)
+
+    assert 5 == PduStorage.reserve_sequence_number(ctx.pid)
+    assert 6 == PduStorage.reserve_sequence_number(ctx.pid)
+    assert 7 == PduStorage.reserve_sequence_number(ctx.pid)
+    assert 8 == PduStorage.reserve_sequence_number(ctx.pid)
+
   end
 
 end


### PR DESCRIPTION
It is, somewhat, useful to persist the storage of sequence numbers. Especially when there can be multiple connections to the same supplier, tracking and hence persisting sequence number is desirable.

Potential, it will now be, possible. To creating your own sequence storage module with the correct behaviour, and hence store sequence numbers in a more persistent medium. 